### PR TITLE
Remove -ncache 10 flag

### DIFF
--- a/scripts/run_x11_vnc.sh
+++ b/scripts/run_x11_vnc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-x11vnc -ncache 10 -ncache_cr -display :1 -forever -shared -logappend /var/log/x11vnc.log -bg -noipv6 -passwd $VNC_SERVER_PASSWORD
+x11vnc -ncache_cr -display :1 -forever -shared -logappend /var/log/x11vnc.log -bg -noipv6 -passwd $VNC_SERVER_PASSWORD


### PR DESCRIPTION
The ncache flag causes VNC sesions on MacOS to have the wrong resolution. You can find more information here: https://unix.stackexchange.com/questions/325793/x-virtual-framebuffer-screen-is-1024x9216-instead-of-1024x768