### PR TITLE
Diff from source `config.ini` from IBC

### DIFF
--- a/config/ibc/config.ini
+++ b/config/ibc/config.ini
@@ -80,12 +80,12 @@ FIX=no
 
 # Your TWS username:
 
-IbLoginId=
+IbLoginId=edemo
 
 
 # Your TWS password:
 
-IbPassword=
+IbPassword=demouser
 
 
 # FIX CTCI Authentication Settings
@@ -154,7 +154,7 @@ SecondFactorAuthenticationExitInterval=
 # 'paper'. For earlier versions of TWS this setting has no
 # effect.
 
-TradingMode=
+TradingMode=live
 
 
 # Paper-trading Account Warning
@@ -168,7 +168,7 @@ TradingMode=
 # confirm acceptance. Setting it to 'no' will leave the dialog
 # on display, and the user will have to deal with it manually.
 
-AcceptNonBrokerageAccountWarning=yes
+AcceptNonBrokerageAccountWarning=no
 
 
 # Login Dialog Display Timeout
@@ -219,7 +219,7 @@ LoginDialogDisplayTimeout = 60
 # The default is the current working directory when IBC is
 # started.
 
-IbDir=/root/Jts
+IbDir=
 
 
 # Store settings on server
@@ -278,7 +278,7 @@ MinimizeMainWindow=no
 #
 # The default is 'manual'.
 
-ExistingSessionDetectedAction=primary
+ExistingSessionDetectedAction=manual
 
 
 # Override TWS API Port Number
@@ -292,7 +292,7 @@ ExistingSessionDetectedAction=primary
 # be set dynamically at run-time: most users will never need it,
 # so don't use it unless you know you need it.
 
-OverrideTwsApiPort=4000
+OverrideTwsApiPort=
 
 
 # Read-only Login
@@ -369,7 +369,7 @@ ReadOnlyApi=
 # However you can change this immmediately by setting
 # SendMarketDataInLotsForUSstocks (see below) to 'no' .
 
-AcceptBidAskLastSizeDisplayUpdateNotification=accept
+AcceptBidAskLastSizeDisplayUpdateNotification=
 
 
 # This setting determines whether the API settings checkbox labelled
@@ -470,7 +470,7 @@ ClosedownAt=
 # configuration page, as this is much more secure (in this case, no
 # incoming API connection dialogs will occur for those IP addresses).
 
-AcceptIncomingConnectionAction=reject
+AcceptIncomingConnectionAction=manual
 
 
 # Allow Blind Trading


### PR DESCRIPTION
See original config sources here:
https://github.com/IbcAlpha/IBC/blob/master/resources/config.ini

Please explain these differences because so far, I have had **zero luck** getting this container to work with the most popular python client for IB's shite api: [`ib_insync`](https://github.com/erdewit/ib_insync).

IMO explaining **WHY YOU MADE THESE CHANGES IS PARAMOUNT** to even having the existence of this project..

Linking https://github.com/IbcAlpha/IBC/issues/67

